### PR TITLE
Update use of createAppAuth in github-api-client.ts

### DIFF
--- a/src/nodes/shared/github-api-client.ts
+++ b/src/nodes/shared/github-api-client.ts
@@ -22,7 +22,7 @@ export class GithubApiClient {
     }
   ) {
     const auth = createAppAuth({
-      id: appId,
+      appId: appId,
       privateKey: privKey,
       installationId: instId,
     });


### PR DESCRIPTION
This update is provided due to the message:
`Deprecation: [@octokit/auth-app] "createAppAuth({ id })" is deprecated, use "createAppAuth({ appId })" instead`
in my Node-RED logs.